### PR TITLE
[BUGFIX] Change json file open mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+*.egg-info/

--- a/citationhelper/citationhelper.py
+++ b/citationhelper/citationhelper.py
@@ -54,7 +54,7 @@ def citehelp(workdirs):
 
 def read_pkg_citations(filename):
 
-    with open(filename, 'ro') as f:
+    with open(filename, 'r') as f:
         citations = json.load(f)
 
     return citations


### PR DESCRIPTION
This bugfix changes the mode the json file is read in from `'ro'` to `'r'`, which is required to make citation helper work on linux.